### PR TITLE
renamed bindShared() method to singleton()

### DIFF
--- a/src/Providers/ToastrServiceProvider.php
+++ b/src/Providers/ToastrServiceProvider.php
@@ -15,7 +15,7 @@ class ToastrServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->bindShared('toastr', function()
+        $this->app->singleton('toastr', function()
         {
             return $this->app->make('\Artdarek\Toastr\Toastr');
         });    


### PR DESCRIPTION
In Laravel 5.2 the bindShared method does not exist. It gets renamed to singleton.
